### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ with gr.Blocks() as demo:
             guidance_scale      = gr.Textbox(label="Guidance scale", value=7.5, info="default: 7.5")
             submit              = gr.Button("Animate")
 
-    def read_video(video):
+    def read_video(video, size=512):
         size = int(size)
         reader = imageio.get_reader(video)
         fps = reader.get_meta_data()['fps']


### PR DESCRIPTION
Hello! Thanks for the cool tool.

I tried to run it in Colab, but it seemed to give me an error when I tried to upload the motion video.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/gradio/queueing.py", line 456, in call_prediction
    output = await route_utils.call_process_api(
  File "/usr/local/lib/python3.10/dist-packages/gradio/route_utils.py", line 232, in call_process_api
    output = await app.get_blocks().process_api(
  File "/usr/local/lib/python3.10/dist-packages/gradio/blocks.py", line 1522, in process_api
    result = await self.call_function(
  File "/usr/local/lib/python3.10/dist-packages/gradio/blocks.py", line 1144, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "/usr/local/lib/python3.10/dist-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/usr/local/lib/python3.10/dist-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/usr/local/lib/python3.10/dist-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/usr/local/lib/python3.10/dist-packages/gradio/utils.py", line 674, in wrapper
    response = f(*args, **kwargs)
  File "/content/MagicAnimate-hf/app.py", line 60, in read_video
    size = int(size)
UnboundLocalError: local variable 'size' referenced before assignment
```

With this fix, I can upload them without any problem, if this fix is ok, I would appreciate it if you could merge it.  
But I would appreciate it if you could point out any problems.

Thank you!